### PR TITLE
Unable to submit local job that has no stdin

### DIFF
--- a/test/src/nl/esciencecenter/octopus/adaptors/local/LocalJobsTest.java
+++ b/test/src/nl/esciencecenter/octopus/adaptors/local/LocalJobsTest.java
@@ -1,0 +1,37 @@
+package nl.esciencecenter.octopus.adaptors.local;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.mock;
+
+import nl.esciencecenter.octopus.engine.OctopusEngine;
+import nl.esciencecenter.octopus.engine.OctopusProperties;
+import nl.esciencecenter.octopus.exceptions.OctopusException;
+import nl.esciencecenter.octopus.jobs.JobDescription;
+import nl.esciencecenter.octopus.jobs.Scheduler;
+
+import org.junit.Test;
+
+public class LocalJobsTest {
+
+    @Test
+    public void submitJob_WithoutStdin_NoException() throws OctopusException {
+        LocalAdaptor adaptor = mock(LocalAdaptor.class);
+        OctopusEngine octopus = mock(OctopusEngine.class);
+        Scheduler scheduler = mock(Scheduler.class);
+
+        String[][] defaults = new String[][] { { LocalAdaptor.MULTIQ_MAX_CONCURRENT, "1"}, { LocalAdaptor.MAX_HISTORY, "10"}, {LocalAdaptor.POLLING_DELAY, "5000"}};
+        OctopusProperties props = new OctopusProperties(defaults);
+        LocalJobs lj = new LocalJobs(props, adaptor, octopus);
+
+        JobDescription description = new JobDescription();
+        description.setExecutable("/bin/sleep");
+        description.setArguments("30");
+        description.setWorkingDirectory("/tmp");
+        description.setStderr("stderr.txt");
+        description.setStdout("stdout.txt");
+        description.setQueueName("multi");
+
+        lj.submitJob(scheduler, description);
+    }
+
+}


### PR DESCRIPTION
The local adaptor can not run non-interactive jobs without stdin.

Attached test throws an invalid job argument exception which is unsuspected.
A job should be able to run without stdin.
