### PR TITLE
Added equals method to Sandbox.

### DIFF
--- a/src/nl/esciencecenter/octopus/util/Sandbox.java
+++ b/src/nl/esciencecenter/octopus/util/Sandbox.java
@@ -48,15 +48,64 @@ public class Sandbox {
             this.destination = destination;
         }
 
-        public AbsolutePath getSource() {
-            return source;
+        @Override
+        public int hashCode() {
+            final int prime = 31;
+            int result = 1;
+            result = prime * result + ((destination == null) ? 0 : destination.hashCode());
+            result = prime * result + ((source == null) ? 0 : source.hashCode());
+            return result;
         }
 
-        public AbsolutePath getDestination() {
-            return destination;
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj) {
+                return true;
+            }
+            if (obj == null) {
+                return false;
+            }
+            if (getClass() != obj.getClass()) {
+                return false;
+            }
+            Pair other = (Pair) obj;
+            if (destination == null) {
+                if (other.destination != null) {
+                    return false;
+                }
+            } else if (!destination.equals(other.destination)) {
+                return false;
+            }
+            if (source == null) {
+                if (other.source != null) {
+                    return false;
+                }
+            } else if (!source.equals(other.source)) {
+                return false;
+            }
+            return true;
+        }
+
+        @Override
+        public String toString() {
+            StringBuilder builder = new StringBuilder();
+            builder.append("Pair [source=").append(source).append(", destination=").append(destination).append("]");
+            return builder.toString();
         }
     }
 
+    /**
+     * Creates a sandbox.
+     *
+     * @param octopus
+     *            An Octopus instance
+     * @param root
+     *            Directory in which sandbox will be created.
+     * @param sandboxName
+     *            Name of the sandbox. If null a random name will be used.
+     * @throws OctopusException
+     * @throws OctopusIOException
+     */
     public Sandbox(Octopus octopus, AbsolutePath root, String sandboxName) throws OctopusException, OctopusIOException {
         this.octopus = octopus;
 
@@ -67,10 +116,16 @@ public class Sandbox {
         }
     }
 
+    /**
+     * @return Path in which files will be uploaded and downloaded.
+     */
     public AbsolutePath getPath() {
         return path;
     }
 
+    /**
+     * @return List of files that will be uploaded on execution of {@Link #upload() upload} method.
+     */
     public List<Pair> getUploadFiles() {
         return uploadFiles;
     }
@@ -82,39 +137,56 @@ public class Sandbox {
         }
     }
 
+    /**
+     * Add a file to the list of files to upload.
+     *
+     * @param src
+     *            Source path of file. Can not be null.
+     */
     public void addUploadFile(AbsolutePath src) {
         addUploadFile(src, null);
     }
 
+    /**
+     * Add a file to the list of files to upload.
+     *
+     * @param src
+     *            Where file should be uploaded from. Can not be null.
+     * @param dest
+     *            Name of file in sandbox. When null the src.getFilename() will be used.
+     */
     public void addUploadFile(AbsolutePath src, String dest) {
         if (src == null) {
-            throw new NullPointerException("the source file cannot be null when adding a preStaged file");
+            throw new NullPointerException("the source path cannot be null when adding a preStaged file");
+        }
+        if (dest == null) {
+            dest = src.getFileName();
         }
 
         uploadFiles.add(new Pair(src, path.resolve(new RelativePath(dest))));
     }
 
+    /**
+     * @return List of files that will be downloaded on execution of {@Link #download() download} method.
+     */
     public List<Pair> getDownloadFiles() {
         return downloadFiles;
     }
 
-// FIXME!
-//
-//    public void setDownloadFiles(String... files) {
-//        downloadFiles = new LinkedList<Pair>();
-//
-//        for (int i = 0; i < files.length; i++) {
-//            addDownloadFile(files[i]);
-//        }
-//    }
-//
-//    public void addDownloadFile(String src) {
-//        addDownloadFile(src, src);
-//    }
-
+    /**
+     * Add file to the list of files to download.
+     *
+     * @param src
+     *            Name of file in sandbox. When null the dest.getFilename() will be used.
+     * @param dest
+     *            Where file should be downloaded to. Can not be null.
+     */
     public void addDownloadFile(String src, AbsolutePath dest) {
+        if (dest == null) {
+            throw new NullPointerException("the destination path cannot be null when adding a postStaged file");
+        }
         if (src == null) {
-            throw new NullPointerException("the source file cannot be null when adding a postStaged file");
+            src = dest.getFileName();
         }
 
         downloadFiles.add(new Pair(path.resolve(new RelativePath(src)), dest));
@@ -158,7 +230,66 @@ public class Sandbox {
         FileUtils.recursiveWipe(octopus, path);
     }
 
+    /**
+     * Deletes all files in sandbox.
+     *
+     * @throws OctopusIOException
+     */
     public void delete() throws OctopusIOException {
         FileUtils.recursiveDelete(octopus, path);
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + ((octopus == null) ? 0 : octopus.hashCode());
+        result = prime * result + ((path == null) ? 0 : path.hashCode());
+        result = prime * result + uploadFiles.hashCode();
+        result = prime * result + downloadFiles.hashCode();
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        Sandbox other = (Sandbox) obj;
+        if (octopus == null) {
+            if (other.octopus != null) {
+                return false;
+            }
+        } else if (!octopus.equals(other.octopus)) {
+            return false;
+        }
+        if (path == null) {
+            if (other.path != null) {
+                return false;
+            }
+        } else if (!path.equals(other.path)) {
+            return false;
+        }
+        if (!downloadFiles.equals(other.downloadFiles)) {
+            return false;
+        }
+        if (!uploadFiles.equals(other.uploadFiles)) {
+            return false;
+        }
+        return true;
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder builder = new StringBuilder();
+        builder.append("Sandbox [octopus=").append(octopus).append(", path=").append(path).append(", uploadFiles=")
+                .append(uploadFiles).append(", downloadFiles=").append(downloadFiles).append("]");
+        return builder.toString();
     }
 }

--- a/test/src/nl/esciencecenter/octopus/util/SandboxTest.java
+++ b/test/src/nl/esciencecenter/octopus/util/SandboxTest.java
@@ -3,6 +3,7 @@ package nl.esciencecenter.octopus.util;
 import static org.junit.Assert.*;
 import static org.hamcrest.CoreMatchers.*;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.verify;
 
@@ -52,7 +53,7 @@ public class SandboxTest {
     }
 
     @Test
-    public void testAddUploadFileAbsolutePathString() throws URISyntaxException, OctopusIOException, OctopusException {
+    public void testAddUploadFile_SrcAndDst() throws URISyntaxException, OctopusIOException, OctopusException {
         Octopus octopus = mock(Octopus.class);
         FileSystem fs = new FileSystemImplementation("local", "local-0", new URI("file:///"), new RelativePath(), null, null);
         AbsolutePath path = new AbsolutePathImplementation(fs, new RelativePath("/tmp"));
@@ -69,7 +70,39 @@ public class SandboxTest {
     }
 
     @Test
-    public void testUpload() throws OctopusIOException, OctopusException, URISyntaxException {
+    public void testAddUploadFile_DstNull_DstSameFileName() throws URISyntaxException, OctopusIOException, OctopusException {
+        Octopus octopus = mock(Octopus.class);
+        FileSystem fs = new FileSystemImplementation("local", "local-0", new URI("file:///"), new RelativePath(), null, null);
+        AbsolutePath path = new AbsolutePathImplementation(fs, new RelativePath("/tmp/sandboxes"));
+        Sandbox sandbox = new Sandbox(octopus, path, "sandbox-1");
+
+        AbsolutePath src = new AbsolutePathImplementation(fs, new RelativePath("/tmp/inputfile"));
+        sandbox.addUploadFile(src, null);
+
+        List<Pair> uploadfiles = sandbox.getUploadFiles();
+        AbsolutePath dst = new AbsolutePathImplementation(fs, new RelativePath("/tmp/sandboxes/sandbox-1/inputfile"));
+        assertThat(uploadfiles.size(), is(1));
+        assertThat(uploadfiles.get(0).source, is(src));
+        assertThat(uploadfiles.get(0).destination, is(dst));
+    }
+
+    @Test
+    public void testAddUploadFile_SrcNull_NullPointerException() throws URISyntaxException, OctopusIOException, OctopusException {
+        Octopus octopus = mock(Octopus.class);
+        FileSystem fs = new FileSystemImplementation("local", "local-0", new URI("file:///"), new RelativePath(), null, null);
+        AbsolutePath path = new AbsolutePathImplementation(fs, new RelativePath("/tmp"));
+        Sandbox sandbox = new Sandbox(octopus, path, "sandbox-1");
+
+        try {
+            sandbox.addUploadFile(null);
+            fail("Expected an NullPointerException");
+        } catch (NullPointerException e) {
+            assertThat(e.getMessage(), is("the source path cannot be null when adding a preStaged file"));
+        }
+    }
+
+    @Test
+    public void testUpload_NoSandboxDir_MkdirAndCopy() throws OctopusIOException, OctopusException, URISyntaxException {
         Octopus octopus = mock(Octopus.class);
         Files files = mock(Files.class);
         when(octopus.files()).thenReturn(files);
@@ -86,4 +119,258 @@ public class SandboxTest {
         AbsolutePath dst = new AbsolutePathImplementation(fs, new RelativePath("/tmp/sandbox-1/input"));
         verify(files).copy(src, dst);
     }
+
+    @Test
+    public void testUpload_SandboxDirExists_Copy() throws OctopusIOException, OctopusException, URISyntaxException {
+        Octopus octopus = mock(Octopus.class);
+        Files files = mock(Files.class);
+        when(octopus.files()).thenReturn(files);
+        FileSystem fs = new FileSystemImplementation("local", "local-0", new URI("file:///"), new RelativePath(), null, null);
+        AbsolutePath path = new AbsolutePathImplementation(fs, new RelativePath("/tmp"));
+        Sandbox sandbox = new Sandbox(octopus, path, "sandbox-1");
+        AbsolutePath sandboxDir = new AbsolutePathImplementation(fs, new RelativePath("/tmp/sandbox-1"));
+        when(files.exists(sandboxDir)).thenReturn(true);
+        AbsolutePath src = new AbsolutePathImplementation(fs, new RelativePath("/tmp/inputfile"));
+        sandbox.addUploadFile(src, "input");
+
+        sandbox.upload();
+
+        verify(files, never()).createDirectory(sandboxDir);
+        AbsolutePath dst = new AbsolutePathImplementation(fs, new RelativePath("/tmp/sandbox-1/input"));
+        verify(files).copy(src, dst);
+    }
+
+    @Test
+    public void testDelete() throws URISyntaxException, OctopusIOException, OctopusException {
+        Octopus octopus = mock(Octopus.class);
+        Files files = mock(Files.class);
+        when(octopus.files()).thenReturn(files);
+        FileSystem fs = new FileSystemImplementation("local", "local-0", new URI("file:///"), new RelativePath(), null, null);
+        AbsolutePath root = new AbsolutePathImplementation(fs, new RelativePath("/tmp"));
+        Sandbox sandbox = new Sandbox(octopus, root, "sandbox-1");
+
+        sandbox.delete();
+
+        AbsolutePath path = new AbsolutePathImplementation(fs, new RelativePath("/tmp/sandbox-1"));
+        verify(files).delete(path);
+    }
+
+    @Test
+    public void testAddDownloadFile_SrcAndDst() throws URISyntaxException, OctopusIOException, OctopusException {
+        Octopus octopus = mock(Octopus.class);
+        FileSystem fs = new FileSystemImplementation("local", "local-0", new URI("file:///"), new RelativePath(), null, null);
+        AbsolutePath path = new AbsolutePathImplementation(fs, new RelativePath("/tmp"));
+        Sandbox sandbox = new Sandbox(octopus, path, "sandbox-1");
+
+        AbsolutePath dst = new AbsolutePathImplementation(fs, new RelativePath("/tmp/outputfile"));
+        sandbox.addDownloadFile("output", dst);
+
+        List<Pair> uploadfiles = sandbox.getDownloadFiles();
+        AbsolutePath src = new AbsolutePathImplementation(fs, new RelativePath("/tmp/sandbox-1/output"));
+        assertThat(uploadfiles.size(), is(1));
+        assertThat(uploadfiles.get(0).source, is(src));
+        assertThat(uploadfiles.get(0).destination, is(dst));
+    }
+
+    @Test
+    public void testAddDownloadFile_SrcNull_SrcSameFileName() throws URISyntaxException, OctopusIOException, OctopusException {
+        Octopus octopus = mock(Octopus.class);
+        FileSystem fs = new FileSystemImplementation("local", "local-0", new URI("file:///"), new RelativePath(), null, null);
+        AbsolutePath path = new AbsolutePathImplementation(fs, new RelativePath("/tmp/sandboxes"));
+        Sandbox sandbox = new Sandbox(octopus, path, "sandbox-1");
+
+        AbsolutePath dst = new AbsolutePathImplementation(fs, new RelativePath("/tmp/outputfile"));
+        sandbox.addDownloadFile(null, dst);
+
+        List<Pair> uploadfiles = sandbox.getDownloadFiles();
+        AbsolutePath src = new AbsolutePathImplementation(fs, new RelativePath("/tmp/sandboxes/sandbox-1/outputfile"));
+        assertThat(uploadfiles.size(), is(1));
+        assertThat(uploadfiles.get(0).source, is(src));
+        assertThat(uploadfiles.get(0).destination, is(dst));
+    }
+
+    @Test
+    public void testAddDownloadFile_DstNull_NullPointerException() throws URISyntaxException, OctopusIOException,
+            OctopusException {
+        Octopus octopus = mock(Octopus.class);
+        FileSystem fs = new FileSystemImplementation("local", "local-0", new URI("file:///"), new RelativePath(), null, null);
+        AbsolutePath path = new AbsolutePathImplementation(fs, new RelativePath("/tmp"));
+        Sandbox sandbox = new Sandbox(octopus, path, "sandbox-1");
+
+        try {
+            sandbox.addDownloadFile("output", null);
+            fail("Expected an NullPointerException");
+        } catch (NullPointerException e) {
+            assertThat(e.getMessage(), is("the destination path cannot be null when adding a postStaged file"));
+        }
+    }
+
+    @Test
+    public void testDownload() throws OctopusIOException, URISyntaxException, OctopusException {
+        Octopus octopus = mock(Octopus.class);
+        Files files = mock(Files.class);
+        when(octopus.files()).thenReturn(files);
+        FileSystem fs = new FileSystemImplementation("local", "local-0", new URI("file:///"), new RelativePath(), null, null);
+        AbsolutePath path = new AbsolutePathImplementation(fs, new RelativePath("/tmp"));
+        Sandbox sandbox = new Sandbox(octopus, path, "sandbox-1");
+        AbsolutePath dst = new AbsolutePathImplementation(fs, new RelativePath("/tmp/outputfile"));
+        sandbox.addDownloadFile("output", dst);
+
+        sandbox.download();
+
+        AbsolutePath src = new AbsolutePathImplementation(fs, new RelativePath("/tmp/sandbox-1/output"));
+        verify(files).copy(src, dst);
+    }
+
+    private Sandbox sampleSandbox() throws URISyntaxException, OctopusException, OctopusIOException {
+        FileSystem fs = new FileSystemImplementation("local", "local-0", new URI("file:///"), new RelativePath(), null, null);
+        AbsolutePath path = new AbsolutePathImplementation(fs, new RelativePath("/tmp"));
+        // Use null for octopus so hashcode is the same every time
+        Sandbox sandbox = new Sandbox(null, path, "sandbox-1");
+        sandbox.addUploadFile(new AbsolutePathImplementation(fs, new RelativePath("/tmp/inputfile")));
+        sandbox.addDownloadFile("outputfile", new AbsolutePathImplementation(fs, new RelativePath("/tmp/outputfile")));
+        return sandbox;
+    }
+
+    @Test
+    public void testHashCode() throws URISyntaxException, OctopusIOException, OctopusException {
+        Sandbox sandbox = sampleSandbox();
+
+        assertEquals(47434737, sandbox.hashCode());
+    }
+
+    @Test
+    public void testToString() throws URISyntaxException, OctopusIOException, OctopusException {
+        Sandbox sandbox = sampleSandbox();
+
+        String expected =
+                "Sandbox [octopus=null, path=FileSystemImplementation [adaptorName=local, uri=file:///, entryPath=RelativePath [element=[], seperator=/], properties=null]RelativePath [element=[tmp, sandbox-1], seperator=/], uploadFiles=[Pair [source=FileSystemImplementation [adaptorName=local, uri=file:///, entryPath=RelativePath [element=[], seperator=/], properties=null]RelativePath [element=[tmp, inputfile], seperator=/], destination=FileSystemImplementation [adaptorName=local, uri=file:///, entryPath=RelativePath [element=[], seperator=/], properties=null]RelativePath [element=[tmp, sandbox-1, inputfile], seperator=/]]], downloadFiles=[Pair [source=FileSystemImplementation [adaptorName=local, uri=file:///, entryPath=RelativePath [element=[], seperator=/], properties=null]RelativePath [element=[tmp, sandbox-1, outputfile], seperator=/], destination=FileSystemImplementation [adaptorName=local, uri=file:///, entryPath=RelativePath [element=[], seperator=/], properties=null]RelativePath [element=[tmp, outputfile], seperator=/]]]]";
+        assertEquals(expected, sandbox.toString());
+    }
+
+    @Test
+    public void testEquals_sameObject_equal() throws URISyntaxException, OctopusIOException, OctopusException {
+        Sandbox sandbox = sampleSandbox();
+
+        assertEquals(sandbox, sandbox);
+    }
+
+    @Test
+    public void testEquals_otherClass_notEqual() throws URISyntaxException, OctopusIOException, OctopusException {
+        Sandbox sandbox = sampleSandbox();
+
+        assertFalse(sandbox.equals(42));
+    }
+
+    @Test
+    public void testEquals_otherNull_notEqual() throws URISyntaxException, OctopusIOException, OctopusException {
+        Sandbox sandbox = sampleSandbox();
+
+        assertFalse(sandbox.equals(null));
+    }
+
+    @Test
+    public void testEquals_otherOctopus_notEqual() throws URISyntaxException, OctopusIOException, OctopusException {
+        Octopus octopus = mock(Octopus.class);
+        Octopus octopus2 = mock(Octopus.class);
+        FileSystem fs = new FileSystemImplementation("local", "local-0", new URI("file:///"), new RelativePath(), null, null);
+        AbsolutePath path = new AbsolutePathImplementation(fs, new RelativePath("/tmp"));
+
+        Sandbox sandbox1 = new Sandbox(octopus, path, "sandbox-1");
+        Sandbox sandbox2 = new Sandbox(octopus2, path, "sandbox-1");
+
+        assertThat(sandbox1, is(not(sandbox2)));
+    }
+
+    @Test
+    public void testEquals_thisOctopusIsNull_notEqual() throws URISyntaxException, OctopusIOException, OctopusException {
+        Octopus octopus = mock(Octopus.class);
+        FileSystem fs = new FileSystemImplementation("local", "local-0", new URI("file:///"), new RelativePath(), null, null);
+        AbsolutePath path = new AbsolutePathImplementation(fs, new RelativePath("/tmp"));
+
+        Sandbox sandbox1 = new Sandbox(null, path, "sandbox-1");
+        Sandbox sandbox2 = new Sandbox(octopus, path, "sandbox-1");
+
+        assertThat(sandbox1, is(not(sandbox2)));
+    }
+
+    @Test
+    public void testEquals_otherOctopusIsNull_notEqual() throws URISyntaxException, OctopusIOException, OctopusException {
+        Octopus octopus = mock(Octopus.class);
+        FileSystem fs = new FileSystemImplementation("local", "local-0", new URI("file:///"), new RelativePath(), null, null);
+        AbsolutePath path = new AbsolutePathImplementation(fs, new RelativePath("/tmp"));
+
+        Sandbox sandbox1 = new Sandbox(octopus, path, "sandbox-1");
+        Sandbox sandbox2 = new Sandbox(null, path, "sandbox-1");
+
+        assertThat(sandbox1, is(not(sandbox2)));
+    }
+
+    @Test
+    public void testEquals_bothOctopusNull_Equal() throws URISyntaxException, OctopusIOException, OctopusException {
+        FileSystem fs = new FileSystemImplementation("local", "local-0", new URI("file:///"), new RelativePath(), null, null);
+        AbsolutePath path = new AbsolutePathImplementation(fs, new RelativePath("/tmp"));
+
+        Sandbox sandbox1 = new Sandbox(null, path, "sandbox-1");
+        Sandbox sandbox2 = new Sandbox(null, path, "sandbox-1");
+
+        assertThat(sandbox1, is(sandbox2));
+    }
+
+    @Test
+    public void testEquals_otherPath_notEqual() throws URISyntaxException, OctopusIOException, OctopusException {
+        Octopus octopus = mock(Octopus.class);
+        FileSystem fs = new FileSystemImplementation("local", "local-0", new URI("file:///"), new RelativePath(), null, null);
+        AbsolutePath path = new AbsolutePathImplementation(fs, new RelativePath("/tmp"));
+
+        Sandbox sandbox1 = new Sandbox(octopus, path, "sandbox-1");
+        Sandbox sandbox2 = new Sandbox(octopus, path, "sandbox-2");
+
+        assertThat(sandbox1, is(not(sandbox2)));
+    }
+
+    @Test
+    public void testEquals_otherUpload_notEqual() throws URISyntaxException, OctopusIOException, OctopusException {
+        Octopus octopus = mock(Octopus.class);
+        FileSystem fs = new FileSystemImplementation("local", "local-0", new URI("file:///"), new RelativePath(), null, null);
+        AbsolutePath path = new AbsolutePathImplementation(fs, new RelativePath("/tmp"));
+
+        Sandbox sandbox1 = new Sandbox(octopus, path, "sandbox-1");
+        AbsolutePath src = new AbsolutePathImplementation(fs, new RelativePath("/tmp/inputfile"));
+        sandbox1.addUploadFile(src);
+        Sandbox sandbox2 = new Sandbox(octopus, path, "sandbox-1");
+
+        assertThat(sandbox1, is(not(sandbox2)));
+    }
+
+    @Test
+    public void testEquals_otherDownload_notEqual() throws URISyntaxException, OctopusIOException, OctopusException {
+        Octopus octopus = mock(Octopus.class);
+        FileSystem fs = new FileSystemImplementation("local", "local-0", new URI("file:///"), new RelativePath(), null, null);
+        AbsolutePath path = new AbsolutePathImplementation(fs, new RelativePath("/tmp"));
+
+        Sandbox sandbox1 = new Sandbox(octopus, path, "sandbox-1");
+        AbsolutePath src = new AbsolutePathImplementation(fs, new RelativePath("/tmp/outputfile"));
+        sandbox1.addDownloadFile("outputfile", src);
+        Sandbox sandbox2 = new Sandbox(octopus, path, "sandbox-1");
+
+        assertThat(sandbox1, is(not(sandbox2)));
+    }
+
+    @Test
+    public void testEquals_sameUpload_Equal() throws URISyntaxException, OctopusIOException, OctopusException {
+        Octopus octopus = mock(Octopus.class);
+        FileSystem fs = new FileSystemImplementation("local", "local-0", new URI("file:///"), new RelativePath(), null, null);
+        AbsolutePath path = new AbsolutePathImplementation(fs, new RelativePath("/tmp"));
+
+        Sandbox sandbox1 = new Sandbox(octopus, path, "sandbox-1");
+        AbsolutePath src = new AbsolutePathImplementation(fs, new RelativePath("/tmp/inputfile"));
+        sandbox1.addUploadFile(src);
+        Sandbox sandbox2 = new Sandbox(octopus, path, "sandbox-1");
+        AbsolutePath src2 = new AbsolutePathImplementation(fs, new RelativePath("/tmp/inputfile"));
+        sandbox2.addUploadFile(src2);
+
+        assertThat(sandbox1, is(sandbox2));
+    }
+
 }


### PR DESCRIPTION
Changed behavior of addUploadFile/addDonwloadFile.
When addUploadFile was used without a destination string the destination path became the sandbox path.
Which throws already exists exception.
Now the sandbox path and the getFileName() of the source path will be used as the destination path.

Added equals method to Sandbox.
Equals was required to test an application that makes a sandbox.

Added documentation to methods.
