### PR TITLE
use a single test config file for all adaptor tests

### DIFF
--- a/test/src/nl/esciencecenter/octopus/adaptors/gridengine/GridEngineJobTestConfig.java
+++ b/test/src/nl/esciencecenter/octopus/adaptors/gridengine/GridEngineJobTestConfig.java
@@ -55,11 +55,11 @@ public class GridEngineJobTestConfig extends JobTestConfig {
         super("gridengine");
 
         if (configfile == null) {
-            configfile = System.getProperty("test.gridengine.adaptor.config");
+            configfile = System.getProperty("test.config");
         }
 
         if (configfile == null) {
-            configfile = System.getProperty("user.home") + File.separator + "test_gridengine.properties";
+            configfile = System.getProperty("user.home") + File.separator + "octopus.test.properties";
         }
 
         Properties p = new Properties();

--- a/test/src/nl/esciencecenter/octopus/adaptors/slurm/SlurmJobTestConfig.java
+++ b/test/src/nl/esciencecenter/octopus/adaptors/slurm/SlurmJobTestConfig.java
@@ -56,11 +56,11 @@ public class SlurmJobTestConfig extends JobTestConfig {
         super("slurm");
 
         if (configfile == null) {
-            configfile = System.getProperty("test.slurm.adaptor.config");
+            configfile = System.getProperty("test.config");
         }
 
         if (configfile == null) {
-            configfile = System.getProperty("user.home") + File.separator + "test_slurm.properties";
+            configfile = System.getProperty("user.home") + File.separator + "octopus.test.properties";
         }
 
         Properties p = new Properties();

--- a/test/src/nl/esciencecenter/octopus/adaptors/ssh/SSHFileTestConfig.java
+++ b/test/src/nl/esciencecenter/octopus/adaptors/ssh/SSHFileTestConfig.java
@@ -49,11 +49,11 @@ public class SSHFileTestConfig extends FileTestConfig {
         super("ssh");
 
         if (configfile == null) {
-            configfile = System.getProperty("test.ssh.adaptor.config");
+            configfile = System.getProperty("test.config");
         }
 
         if (configfile == null) {
-            configfile = System.getProperty("user.home") + File.separator + "test_ssh.properties";
+            configfile = System.getProperty("user.home") + File.separator + "octopus.test.properties";
         }
 
         Properties p = new Properties();

--- a/test/src/nl/esciencecenter/octopus/adaptors/ssh/SSHJobTestConfig.java
+++ b/test/src/nl/esciencecenter/octopus/adaptors/ssh/SSHJobTestConfig.java
@@ -51,11 +51,11 @@ public class SSHJobTestConfig extends JobTestConfig {
         super("ssh");
 
         if (configfile == null) {
-            configfile = System.getProperty("test.ssh.adaptor.config");
+            configfile = System.getProperty("test.config");
         }
 
         if (configfile == null) {
-            configfile = System.getProperty("user.home") + File.separator + "test_ssh.properties";
+            configfile = System.getProperty("user.home") + File.separator + "octopus.test.properties";
         }
 
         Properties p = new Properties();


### PR DESCRIPTION
This should also enable testing the slurm and gridengine adaptors on the jenkins machine
