### PR TITLE
added support for slurm 2.6 (ran tests agains cartesius)

### DIFF
--- a/src/nl/esciencecenter/xenon/adaptors/slurm/SlurmSetup.java
+++ b/src/nl/esciencecenter/xenon/adaptors/slurm/SlurmSetup.java
@@ -32,7 +32,7 @@ public class SlurmSetup {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(SlurmSetup.class);
 
-    private static final String[] SUPPORTED_VERSIONS = { "2.3.", "2.5." };
+    private static final String[] SUPPORTED_VERSIONS = { "2.3.", "2.5.", "2.6."};
 
     private final boolean accountingAvailable;
     private final String version;
@@ -68,7 +68,7 @@ public class SlurmSetup {
                     SlurmAdaptor.IGNORE_VERSION_PROPERTY);
         } else {
             throw new IncompatibleVersionException(SlurmAdaptor.ADAPTOR_NAME, "Slurm version " + version
-                    + " not supported by Slurm Adaptor. Set " + SlurmAdaptor.IGNORE_VERSION_PROPERTY + "to ignore");
+                    + " not supported by Slurm Adaptor. Set " + SlurmAdaptor.IGNORE_VERSION_PROPERTY + " to ignore");
         }
     }
 


### PR DESCRIPTION
Added support for SLURM 2.6.\* by white listing the version in the SLURM adaptor. Tested against Cartesius (passes entire test set) (Also fixed typo in exception message)
