### PR TITLE
Fix link: xenon tutorial.

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -23,10 +23,9 @@ to improve the Xenon API and implementation. </p>
 
 <p>
 The latest source code and issue tracker can be found on <a href="https://github.com/xenon-middleware/xenon">Github</a>.
-</p><p>
-See <a href="https://github.com/xenon-middleware/Xenon-examples">https://github.com/xenon-middleware/Xenon-examples</a> for examples how to use the Xenon library.
-</p><p>
-See <a href="https://github.com/xenon-middleware/Xenon-examples/raw/master/doc/tutorial/xenon-tutorial.pdf">xenon-tutorial.pdf</a> for a tutorial pdf targeting inexperienced users.
+</p>
+<p>
+See the <a href="https://xenon-tutorial.readthedocs.io/en/latest/">Xenon library tutorial</a> including examples of use.
 </p>
 
 <h2>


### PR DESCRIPTION
The link to the tutorial in PDF is broken.