### PR TITLE
Add extra ignore-lines to slurm config parsing

### DIFF
--- a/src/main/java/nl/esciencecenter/xenon/adaptors/schedulers/slurm/SlurmScheduler.java
+++ b/src/main/java/nl/esciencecenter/xenon/adaptors/schedulers/slurm/SlurmScheduler.java
@@ -80,8 +80,19 @@ public class SlurmScheduler extends ScriptingScheduler {
         String output = runCheckedCommand(null, "scontrol", "show", "config");
 
         // Parse output. Ignore some header and footer lines.
-        Map<String, String> info = ScriptingParser.parseKeyValueLines(output, ScriptingParser.EQUALS_REGEX, ADAPTOR_NAME, "Configuration data as of",
-                "Slurmctld(primary/backup) at", "Account Gather");
+        // See:
+        //  - https://github.com/SchedMD/slurm/blob/slurm-20-02-0-1/src/api/config_info.c#L420
+        //  - https://github.com/SchedMD/slurm/blob/slurm-20-02-0-1/src/api/config_info.c#L443
+        Map<String, String> info = ScriptingParser.parseKeyValueLines(output, ScriptingParser.EQUALS_REGEX, ADAPTOR_NAME,
+                "Configuration data as of",
+                "Slurmctld(primary",                            // Slurmctld(primary/backup) or Slurmctld(primary)
+                "Account Gather",
+                "Cgroup Support Configuration",
+                "External Sensors Configuration",
+                "Node Features Configuration",
+                "Slurmctld Plugstack Plugins Configuration",
+                "-----"                                         // When printing plugin configuration (sub-heading)
+        );
 
         setup = new SlurmSetup(info, disableAccounting);
 


### PR DESCRIPTION
I get the following exceptions when connecting to some clusters through PyXenon.

Cyfronet & Lisa:
```
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "<stdin>", line 7, in create_scheduler
  File "/Users/onno/.local/share/virtualenvs/adaptor-lofar-download-yKJH8DDq/lib/python3.7/site-packages/xenon/oop.py", line 304, in static_method
    grpc_call(cls.__stub__(__server__), m, request))
  File "/Users/onno/.local/share/virtualenvs/adaptor-lofar-download-yKJH8DDq/lib/python3.7/site-packages/xenon/oop.py", line 271, in grpc_call
    raise make_exception(method, e) from None
xenon.exceptions.XenonException: Xenon (StatusCode.INTERNAL): "nl.esciencecenter.xenon.XenonException: slurm adaptor: Got invalid key/value pair in output: Cgroup Support Configuration:" in create
``` 
 
LRZ:
```
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "<stdin>", line 7, in create_scheduler
  File "/Users/onno/.local/share/virtualenvs/adaptor-lofar-download-yKJH8DDq/lib/python3.7/site-packages/xenon/oop.py", line 304, in static_method
    grpc_call(cls.__stub__(__server__), m, request))
  File "/Users/onno/.local/share/virtualenvs/adaptor-lofar-download-yKJH8DDq/lib/python3.7/site-packages/xenon/oop.py", line 271, in grpc_call
    raise make_exception(method, e) from None
xenon.exceptions.XenonException: Xenon (StatusCode.INTERNAL): "nl.esciencecenter.xenon.XenonException: slurm adaptor: Got invalid key/value pair in output: Node Features Configuration:" in create
```

I expect this is caused by `Cgroup Support Configuration` and `Node Features Configuration` not being ignored while parsing the Slurm configuration. Therefore, I checked the [SLURM code responsible for config printing](https://github.com/SchedMD/slurm/blob/master/src/api/config_info.c#L443) and added any missing headings to the `ignoredLines` parameter of the `ScriptingParser.parseKeyValueLines()` call in the `SlurmScheduler` class constructor.

The `-----` ignore line is to cover sub-headings when [plugin configuration is printed](https://github.com/SchedMD/slurm/blob/master/src/api/config_info.c#L420), e.g.:

```
Node Features Configuration:
----- node_features/knl_generic -----
AllowMCDRAM             = cache,hybrid,flat,equal,auto
AllowNUMA               = a2a,snc2,snc4,hemi,quad
AllowUserBoot           = ALL
BootTime                = 300
DefaultMCDRAM           = cache
DefaultNUMA             = a2a
Force                   = 0
McPath                  = /sys/devices/system/edac/mc
NodeRebootWeight        = 4294967294
SyscfgPath              = /usr/bin/syscfg
SyscfgTimeout           = 1000
SystemType              = Intel
UmeCheckInterval        = 0
```