### PR TITLE
Added scheduler arguments to interactive jobs. Fixes #675

### DIFF
--- a/src/main/java/nl/esciencecenter/xenon/adaptors/schedulers/slurm/SlurmUtils.java
+++ b/src/main/java/nl/esciencecenter/xenon/adaptors/schedulers/slurm/SlurmUtils.java
@@ -375,6 +375,9 @@ public final class SlurmUtils {
         // add maximum runtime
         arguments.add("--time=" + runtime);
 
+        // add scheduler arguments
+        arguments.addAll(description.getSchedulerArguments());
+
         arguments.add(description.getExecutable());
         arguments.addAll(description.getArguments());
 

--- a/src/test/java/nl/esciencecenter/xenon/adaptors/schedulers/slurm/SlurmUtilsTest.java
+++ b/src/test/java/nl/esciencecenter/xenon/adaptors/schedulers/slurm/SlurmUtilsTest.java
@@ -642,6 +642,24 @@ public class SlurmUtilsTest {
     }
 
     @Test
+    public void test_generateInterActiveSchedulerArguments() {
+        Path entry = new Path("/entry");
+        UUID tag = new UUID(0, 42);
+
+        JobDescription description = new JobDescription();
+        description.setExecutable("exec");
+        description.setSchedulerArguments(new String[] { "--nodelist=node-2" });
+        description.setArguments(new String[] { "a", "b", "c" });
+
+        String[] expected = new String[] { "--quiet", "--job-name=" + tag.toString(), "--ntasks=1", "--cpus-per-task=1", "--time=15", "--nodelist=node-2",
+                "exec", "a", "b", "c" };
+
+        String[] result = SlurmUtils.generateInteractiveArguments(description, entry, tag, 15);
+
+        assertArrayEquals(expected, result);
+    }
+
+    @Test
     public void test_generateInterActiveMemory() {
         Path entry = new Path("/entry");
         UUID tag = new UUID(0, 42);


### PR DESCRIPTION
This patch add the forgotten scheduler argument to interactive slurm jobs. Batch jobs already took these into account. Also added unit test for this case.