### PR TITLE
Added support for son-of-gridengine 8.1.9

### DIFF
--- a/src/integrationTest/java/nl/esciencecenter/xenon/adaptors/schedulers/sonofgridengine/SonofgridengineLocationConfig.java
+++ b/src/integrationTest/java/nl/esciencecenter/xenon/adaptors/schedulers/sonofgridengine/SonofgridengineLocationConfig.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2013 Netherlands eScience Center
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nl.esciencecenter.xenon.adaptors.schedulers.sonofgridengine;
+
+import nl.esciencecenter.xenon.adaptors.schedulers.SchedulerLocationConfig;
+
+public class SonofgridengineLocationConfig extends SchedulerLocationConfig {
+
+    public SonofgridengineLocationConfig(String location, String workdir) {
+        super(location, workdir, new String[] { "all.q", "default", "slow" }, null);
+    }
+}

--- a/src/integrationTest/java/nl/esciencecenter/xenon/adaptors/schedulers/sonofgridengine/SonofgridengineSchedulerDockerTest.java
+++ b/src/integrationTest/java/nl/esciencecenter/xenon/adaptors/schedulers/sonofgridengine/SonofgridengineSchedulerDockerTest.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2013 Netherlands eScience Center
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nl.esciencecenter.xenon.adaptors.schedulers.sonofgridengine;
+
+import static nl.esciencecenter.xenon.adaptors.schedulers.ssh.SshSchedulerAdaptor.LOAD_STANDARD_KNOWN_HOSTS;
+import static nl.esciencecenter.xenon.adaptors.schedulers.ssh.SshSchedulerAdaptor.STRICT_HOST_KEY_CHECKING;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assume.assumeFalse;
+import static org.junit.Assume.assumeTrue;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.ClassRule;
+import org.junit.Test;
+
+import com.palantir.docker.compose.DockerComposeRule;
+import com.palantir.docker.compose.connection.waiting.HealthChecks;
+
+import nl.esciencecenter.xenon.XenonException;
+import nl.esciencecenter.xenon.adaptors.schedulers.SchedulerLocationConfig;
+import nl.esciencecenter.xenon.credentials.PasswordCredential;
+import nl.esciencecenter.xenon.schedulers.JobDescription;
+import nl.esciencecenter.xenon.schedulers.JobStatus;
+import nl.esciencecenter.xenon.schedulers.Scheduler;
+import nl.esciencecenter.xenon.utils.LocalFileSystemUtils;
+
+public class SonofgridengineSchedulerDockerTest extends SonofgridengineSchedulerTestParent {
+
+    @ClassRule
+    public static DockerComposeRule docker = DockerComposeRule.builder().file("src/integrationTest/resources/docker-compose/sonofgridengine-8.1.9.yml")
+            .waitingForService("sonofgridengine", HealthChecks.toHaveAllPortsOpen()).build();
+
+    @Override
+    protected SchedulerLocationConfig setupLocationConfig() {
+        return new SonofgridengineLocationConfig(docker.containers().container("sonofgridengine").port(22).inFormat("ssh://$HOST:$EXTERNAL_PORT"),
+                "/home/xenon");
+    }
+
+    @Override
+    public Scheduler setupScheduler(SchedulerLocationConfig config) throws XenonException {
+        // String location = docker.containers().container("gridengine").port(22).inFormat("ssh://$HOST:$EXTERNAL_PORT");
+        PasswordCredential cred = new PasswordCredential("xenon", "javagat".toCharArray());
+        Map<String, String> props = new HashMap<>();
+        props.put(LOAD_STANDARD_KNOWN_HOSTS, "false");
+        props.put(STRICT_HOST_KEY_CHECKING, "false");
+        return Scheduler.create("gridengine", config.getLocation(), cred, props);
+    }
+
+    @Test
+    public void test_submitBatch_peUsingSchedulerArg() throws XenonException {
+        // This test does not run on windows.
+        assumeFalse("Test only suited for linux", scheduler.getAdaptorName().equals("local") && (LocalFileSystemUtils.isWindows()));
+        assumeTrue(description.supportsBatch());
+
+        JobDescription job = new JobDescription();
+        job.setExecutable("/bin/hostname");
+        job.addSchedulerArgument("-pe smp 2");
+
+        String jobID = scheduler.submitBatchJob(job);
+
+        JobStatus status = waitUntilDone(jobID);
+
+        assertTrue("Job is not done yet", status.isDone());
+    }
+
+    @Test
+    public void test_submitBatch_peUsingCoreCount() throws XenonException {
+        // This test does not run on windows.
+        assumeFalse("Test only suited for linux", scheduler.getAdaptorName().equals("local") && (LocalFileSystemUtils.isWindows()));
+        assumeTrue(description.supportsBatch());
+
+        JobDescription job = new JobDescription();
+        job.setExecutable("/bin/hostname");
+        job.setCoresPerTask(2);
+        job.setStartPerJob();
+
+        String jobID = scheduler.submitBatchJob(job);
+
+        JobStatus status = waitUntilDone(jobID);
+
+        assertTrue("Job is not done yet", status.isDone());
+    }
+
+}

--- a/src/integrationTest/java/nl/esciencecenter/xenon/adaptors/schedulers/sonofgridengine/SonofgridengineSchedulerTestParent.java
+++ b/src/integrationTest/java/nl/esciencecenter/xenon/adaptors/schedulers/sonofgridengine/SonofgridengineSchedulerTestParent.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2013 Netherlands eScience Center
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nl.esciencecenter.xenon.adaptors.schedulers.sonofgridengine;
+
+import nl.esciencecenter.xenon.adaptors.schedulers.SchedulerTestParent;
+
+/**
+ * Extend this class for docker tests and live tests
+ *
+ * Can contain extra tests for gridengine scheduler
+ */
+public abstract class SonofgridengineSchedulerTestParent extends SchedulerTestParent {
+
+}

--- a/src/integrationTest/resources/docker-compose/sonofgridengine-8.1.9.yml
+++ b/src/integrationTest/resources/docker-compose/sonofgridengine-8.1.9.yml
@@ -1,0 +1,24 @@
+#
+# Copyright 2013 Netherlands eScience Center
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+version: '3'
+services:
+  sonofgridengine:
+    image: xenonmiddleware/sonofgridengine
+    hostname: xenon-sonofge
+    ports:
+    - 22 # ssh
+

--- a/src/main/java/nl/esciencecenter/xenon/adaptors/schedulers/gridengine/GridEngineXmlParser.java
+++ b/src/main/java/nl/esciencecenter/xenon/adaptors/schedulers/gridengine/GridEngineXmlParser.java
@@ -28,9 +28,6 @@ import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
 
-import nl.esciencecenter.xenon.XenonException;
-import nl.esciencecenter.xenon.adaptors.schedulers.IncompatibleVersionException;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.w3c.dom.Document;
@@ -39,19 +36,24 @@ import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 import org.xml.sax.SAXException;
 
+import nl.esciencecenter.xenon.XenonException;
+import nl.esciencecenter.xenon.adaptors.schedulers.IncompatibleVersionException;
+
 /**
- * Parses xml output from various grid engine command line tools. For more info on the output, see the
- * "N1 Grid Engine 6 User's Guide". Retrieved from: http://docs.oracle.com/cd/E19080-01/n1.grid.eng6/817-6117/chp11-1/index.html
+ * Parses xml output from various grid engine command line tools. For more info on the output, see the "N1 Grid Engine 6 User's Guide". Retrieved from:
+ * http://docs.oracle.com/cd/E19080-01/n1.grid.eng6/817-6117/chp11-1/index.html
  *
  */
 public class GridEngineXmlParser {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(GridEngineXmlParser.class);
 
-    //Tag containing version of xml schema used in qstat -xml output
+    // Tag containing version of xml schema used in qstat -xml output
     private static final String SGE62_SCHEMA_ATTRIBUTE = "xmlns:xsd";
 
     private static final String SGE62_SCHEMA_VALUE = "http://gridengine.sunsource.net/source/browse/*checkout*/gridengine/source/dist/util/resources/schemas/qstat/qstat.xsd?revision=1.11";
+
+    private static final String SONOFSGE819_SCHEMA_VALUE = "http://arc.liv.ac.uk/repos/darcs/sge/source/dist/util/resources/schemas/qstat/qstat.xsd";
 
     private final DocumentBuilder documentBuilder;
 
@@ -71,16 +73,14 @@ public class GridEngineXmlParser {
     private void checkVersion(Document document) throws IncompatibleVersionException {
         Element documentElement = document.getDocumentElement();
 
-        if (!documentElement.getAttribute(SGE62_SCHEMA_ATTRIBUTE).equals(SGE62_SCHEMA_VALUE)) {
+        if (!(documentElement.getAttribute(SGE62_SCHEMA_ATTRIBUTE).equals(SGE62_SCHEMA_VALUE)
+                || documentElement.getAttribute(SGE62_SCHEMA_ATTRIBUTE).equals(SONOFSGE819_SCHEMA_VALUE))) {
             if (ignoreVersion) {
-                LOGGER.warn("cannot determine version, version attribute found: \""
-                        + documentElement.getAttribute(SGE62_SCHEMA_ATTRIBUTE) + "\". Ignoring as requested by "
-                        + IGNORE_VERSION_PROPERTY);
+                LOGGER.warn("cannot determine version, version attribute found: \"" + documentElement.getAttribute(SGE62_SCHEMA_ATTRIBUTE)
+                        + "\". Ignoring as requested by " + IGNORE_VERSION_PROPERTY);
             } else {
-                throw new IncompatibleVersionException(ADAPTOR_NAME,
-                        "cannot determine version, version attribute found: \""
-                                + documentElement.getAttribute(SGE62_SCHEMA_ATTRIBUTE) + "\". Use the "
-                                + IGNORE_VERSION_PROPERTY + " property to ignore this error");
+                throw new IncompatibleVersionException(ADAPTOR_NAME, "cannot determine version, version attribute found: \""
+                        + documentElement.getAttribute(SGE62_SCHEMA_ATTRIBUTE) + "\". Use the " + IGNORE_VERSION_PROPERTY + " property to ignore this error");
             }
 
         }
@@ -107,7 +107,7 @@ public class GridEngineXmlParser {
 
         NodeList tagNodes = root.getChildNodes();
 
-        //fetch tags from the list of tag nodes. Ignores empty values
+        // fetch tags from the list of tag nodes. Ignores empty values
         for (int j = 0; j < tagNodes.getLength(); j++) {
             Node tagNode = tagNodes.item(j);
             if (tagNode.getNodeType() == Node.ELEMENT_NODE) {

--- a/src/testApi/java/nl/esciencecenter/xenon/adaptors/schedulers/SchedulerTestParent.java
+++ b/src/testApi/java/nl/esciencecenter/xenon/adaptors/schedulers/SchedulerTestParent.java
@@ -450,9 +450,19 @@ public abstract class SchedulerTestParent {
         String jobID = scheduler.submitBatchJob(getSleepJob(queueNames[0], 1));
 
         JobStatus status = scheduler.waitUntilDone(jobID, 5000);
-
         assertNotNull(status);
         Assert.assertEquals(jobID, status.getJobIdentifier());
+
+        // NOTE: Some schedulers have issues changing the job status to "finished" quickly enough. Therefore, we retry a number of times.
+        int retry = 1;
+
+        while (retry < 12 && !status.isDone()) {
+            retry++;
+            status = scheduler.waitUntilDone(jobID, 5000);
+            assertNotNull(status);
+            Assert.assertEquals(jobID, status.getJobIdentifier());
+        }
+
         assertTrue(status.isDone());
 
         // Wait for a while and see if we can still get the job info.


### PR DESCRIPTION
This PR add support for son-of-gridengine, whose behavior differs slightly from the normal gridengine implementation. Also adds unit and integration tests 